### PR TITLE
Fixes npm run preview error

### DIFF
--- a/src/components/router-head/router-head.tsx
+++ b/src/components/router-head/router-head.tsx
@@ -12,7 +12,7 @@ export const RouterHead = component$(() => {
     <>
       <title>{head.title}</title>
 
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={loc.url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 


### PR DESCRIPTION
This is to fix issue #1 

Steps to reproduce the issue:
- Open the project https://stackblitz.com/~/github.com/hirezio/qwik-intro-app
- Run `npm run preview`
- You will get the error below
```
error TS2339: Property 'href' does not exist on type 'RouteLocation'
```
